### PR TITLE
rng-tools: add optional depend of opensc

### DIFF
--- a/rng-tools/trunk/PKGBUILD
+++ b/rng-tools/trunk/PKGBUILD
@@ -9,6 +9,7 @@ arch=('x86_64')
 url="https://github.com/nhorman/rng-tools"
 license=('GPL')
 depends=('libgcrypt' 'curl' 'libxml2' 'sysfsutils' 'jitterentropy' 'libp11')
+optdepends=("opensc: for PKCS#11 tokens support")
 backup=(etc/conf.d/rngd)
 source=(https://github.com/nhorman/rng-tools/archive/v$pkgver/$pkgname-$pkgver.tar.gz
         rngd.conf


### PR DESCRIPTION
Not sure if it is OK to add PR in this repository.

rng-tools added support PKCS#11 token support: https://github.com/nhorman/rng-tools/issues/24 , which needs library (/usr/lib/opensc-pkcs11.so) in opensc.